### PR TITLE
Optimize CUFFT hot paths with reusable plans

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParticleHolography"
 uuid = "b8f7f481-73e0-42c6-b6bd-c66d3b4942cc"
 authors = ["Dai Nakai <dnakaikit@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -16,6 +16,7 @@ ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,3 +4,6 @@ DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 ParticleHolography = "b8f7f481-73e0-42c6-b6bd-c66d3b4942cc"
+
+[compat]
+ParticleHolography = "0.2.2"

--- a/src/frequency_filters.jl
+++ b/src/frequency_filters.jl
@@ -1,4 +1,6 @@
 using CUDA
+using CUDA.CUFFT
+using LinearAlgebra
 
 export cu_rectangle_filter, cu_super_gaussian_filter, cu_apply_low_pass_filter, cu_apply_low_pass_filter!
 
@@ -86,7 +88,14 @@ Apply a low pass filter to the wavefront `holo`. The low pass filter is applied 
 - `nothing`
 """
 function cu_apply_low_pass_filter!(holo::CuWavefront, lpf::CuLowPassFilter)
-    holo.data .= CUFFT.ifft(CUFFT.ifftshift(lpf.data .* CUFFT.fftshift(CUFFT.fft(holo.data))))
+    fft_arr = similar(holo.data)
+    ifft_in = similar(holo.data)
+    fft_plan = CUFFT.plan_fft(holo.data)
+    ifft_plan = CUFFT.plan_ifft(holo.data)
+
+    LinearAlgebra.mul!(fft_arr, fft_plan, holo.data)
+    ifft_in .= CUFFT.ifftshift(lpf.data .* CUFFT.fftshift(fft_arr))
+    LinearAlgebra.mul!(holo.data, ifft_plan, ifft_in)
     return nothing
 end
 
@@ -103,5 +112,14 @@ Apply a low pass filter to the wavefront `holo`. The low pass filter is applied 
 - `CuWavefront{ComplexF32}`: The wavefront after applying the low pass filter.
 """
 function cu_apply_low_pass_filter(holo::CuWavefront, lpf::CuLowPassFilter)
-    return CuWavefront(CUFFT.ifft(CUFFT.ifftshift(lpf.data .* CUFFT.fftshift(CUFFT.fft(holo.data)))))
+    fft_arr = similar(holo.data)
+    ifft_in = similar(holo.data)
+    filtered = similar(holo.data)
+    fft_plan = CUFFT.plan_fft(holo.data)
+    ifft_plan = CUFFT.plan_ifft(holo.data)
+
+    LinearAlgebra.mul!(fft_arr, fft_plan, holo.data)
+    ifft_in .= CUFFT.ifftshift(lpf.data .* CUFFT.fftshift(fft_arr))
+    LinearAlgebra.mul!(filtered, ifft_plan, ifft_in)
+    return CuWavefront(filtered)
 end

--- a/src/holofunc.jl
+++ b/src/holofunc.jl
@@ -1,6 +1,7 @@
 using CUDA
 using CUDA.CUFFT
 using FixedPointNumbers
+using LinearAlgebra
 
 export cu_transfer_sqrt_arr, cu_transfer, cu_gabor_wavefront, cu_phase_retrieval_holo, cu_get_reconst_vol, cu_get_reconst_xyprojection, cu_get_reconst_vol_and_xyprojection, cu_get_reconst_complex_vol
 export cu_asm_prop!, cu_2d_pad, cu_get_reconst_vol_and_xyprojection_padded
@@ -102,23 +103,33 @@ function cu_phase_retrieval_holo(holo1::CuArray{Float32,2}, holo2::CuArray{Float
 
     light1 = CuArray{ComplexF32}(undef, datlen, datlen)
     light2 = CuArray{ComplexF32}(undef, datlen, datlen)
+    light1_fft = similar(light1)
+    light2_fft = similar(light2)
+    light1_ifft_in = similar(light1)
+    light2_ifft_in = similar(light2)
     phi1 = CuArray{Float32}(undef, datlen, datlen)
     phi2 = CuArray{Float32}(undef, datlen, datlen)
     sqrtI1 = sqrt.(holo1)
     sqrtI2 = sqrt.(holo2)
+    fft_plan = CUFFT.plan_fft(light1)
+    ifft_plan = CUFFT.plan_ifft(light1)
 
     light1 .= sqrtI1 .+ 0.0im
 
     for _ in 1:priter
         # STEP1
-        light2 .= CUFFT.ifft(CUFFT.ifftshift(CUFFT.fftshift(CUFFT.fft(light1)) .* transfer.data))
+        LinearAlgebra.mul!(light1_fft, fft_plan, light1)
+        light2_ifft_in .= CUFFT.ifftshift(CUFFT.fftshift(light1_fft) .* transfer.data)
+        LinearAlgebra.mul!(light2, ifft_plan, light2_ifft_in)
         phi2 .= angle.(light2)
 
         # STEP2
         light2 .= sqrtI2 .* exp.(1.0im .* phi2)
 
         # STEP3
-        light1 .= CUFFT.ifft(CUFFT.ifftshift(CUFFT.fftshift(CUFFT.fft(light2)) .* invtransfer.data))
+        LinearAlgebra.mul!(light2_fft, fft_plan, light2)
+        light1_ifft_in .= CUFFT.ifftshift(CUFFT.fftshift(light2_fft) .* invtransfer.data)
+        LinearAlgebra.mul!(light1, ifft_plan, light1_ifft_in)
         phi1 .= angle.(light1)
 
         # STEP4
@@ -155,14 +166,28 @@ function _normedfloat_to_N0f8(val::AbstractFloat)
     return reinterpret(N0f8, round(UInt8, clamp(val, 0.0, 1.0) * 255))
 end
 
-function _ifft_and_abs(fftholo, return_type::Type)
+function _ifft_from_shifted_fft!(out::AbstractArray{T,2}, fftholo::CuArray{T,2}, ifft_plan, ifft_workspace::CuArray{T,2}) where {T<:Complex}
+    ifft_workspace .= CUFFT.ifftshift(fftholo)
+    LinearAlgebra.mul!(out, ifft_plan, ifft_workspace)
+    return nothing
+end
+
+function _ifft_and_abs!(out::AbstractArray, fftholo::CuArray{T,2}, return_type::Type, ifft_plan, ifft_workspace::CuArray{T,2}, ifft_output::CuArray{T,2}) where {T<:Complex}
+    _ifft_from_shifted_fft!(ifft_output, fftholo, ifft_plan, ifft_workspace)
     if return_type in [Float32, Float64, Float16]
-        return fftholo |> CUFFT.ifftshift |> CUFFT.ifft .|> (x -> abs2(x)) .|> (x -> clamp(x, 0.0, 1.0)) .|> return_type
+        out .= return_type.(clamp.(abs2.(ifft_output), 0.0, 1.0))
     elseif return_type == N0f8
-        return fftholo |> CUFFT.ifftshift |> CUFFT.ifft .|> (x -> abs2(x)) .|> (x -> clamp(x, 0.0, 1.0)) .|> _normedfloat_to_N0f8
+        out .= _normedfloat_to_N0f8.(clamp.(abs2.(ifft_output), 0.0, 1.0))
     else
         throw(ArgumentError("return_type must be Subtype of AbstractFloat or N0f8. Got $return_type"))
     end
+    return nothing
+end
+
+function _ifft_abs2_float32!(out::AbstractArray{Float32,2}, fftholo::CuArray{T,2}, ifft_plan, ifft_workspace::CuArray{T,2}, ifft_output::CuArray{T,2}) where {T<:Complex}
+    _ifft_from_shifted_fft!(ifft_output, fftholo, ifft_plan, ifft_workspace)
+    out .= Float32.(abs2.(ifft_output))
+    return nothing
 end
 
 
@@ -185,15 +210,21 @@ function cu_get_reconst_vol(wavefront::CuWavefront{ComplexF32}, transfer_front::
     @assert size(wavefront.data) == size(transfer_front.data) == size(transfer_dz.data) "All arrays must have the same size. Got $(size(wavefront.data)), $(size(transfer_front.data)), $(size(transfer_dz.data))."
 
     vol = CuArray{return_type}(undef, size(wavefront.data)..., slices)
+    fftholo_fft = similar(wavefront.data)
+    ifft_workspace = similar(wavefront.data)
+    ifft_output = similar(wavefront.data)
+    fft_plan = CUFFT.plan_fft(wavefront.data)
+    ifft_plan = CUFFT.plan_ifft(wavefront.data)
 
-    fftholo = CUFFT.fftshift(CUFFT.fft(wavefront.data))
+    LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
+    fftholo = CUFFT.fftshift(fftholo_fft)
     fftholo .= fftholo .* transfer_front.data
 
-    vol[:, :, 1] .= _ifft_and_abs(fftholo, return_type)
+    _ifft_and_abs!(view(vol, :, :, 1), fftholo, return_type, ifft_plan, ifft_workspace, ifft_output)
 
     for i in 2:slices
         fftholo .= fftholo .* transfer_dz.data
-        vol[:, :, i] .= _ifft_and_abs(fftholo, return_type)
+        _ifft_and_abs!(view(vol, :, :, i), fftholo, return_type, ifft_plan, ifft_workspace, ifft_output)
     end
 
     return vol
@@ -217,15 +248,20 @@ function cu_get_reconst_complex_vol(wavefront::CuWavefront{ComplexF32}, transfer
     @assert size(wavefront.data) == size(transfer_front.data) == size(transfer_dz.data) "All arrays must have the same size. Got $(size(wavefront.data)), $(size(transfer_front.data)), $(size(transfer_dz.data))."
 
     vol = CuArray{ComplexF32}(undef, size(wavefront.data)..., slices)
+    fftholo_fft = similar(wavefront.data)
+    ifft_workspace = similar(wavefront.data)
+    fft_plan = CUFFT.plan_fft(wavefront.data)
+    ifft_plan = CUFFT.plan_ifft(wavefront.data)
 
-    fftholo = CUFFT.fftshift(CUFFT.fft(wavefront.data))
+    LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
+    fftholo = CUFFT.fftshift(fftholo_fft)
     fftholo .= fftholo .* transfer_front.data
 
-    vol[:, :, 1] .= fftholo |> CUFFT.ifftshift |> CUFFT.ifft
+    _ifft_from_shifted_fft!(view(vol, :, :, 1), fftholo, ifft_plan, ifft_workspace)
 
     for i in 2:slices
         fftholo .= fftholo .* transfer_dz.data
-        vol[:, :, i] .= fftholo |> CUFFT.ifftshift |> CUFFT.ifft
+        _ifft_from_shifted_fft!(view(vol, :, :, i), fftholo, ifft_plan, ifft_workspace)
     end
 
     return vol
@@ -250,15 +286,21 @@ function cu_get_reconst_xyprojection(wavefront::CuWavefront{ComplexF32}, transfe
 
     proj = CuArray{Float32}(undef, size(wavefront.data)...)
     projtmp = CuArray{Float32}(undef, size(wavefront.data)...)
+    fftholo_fft = similar(wavefront.data)
+    ifft_workspace = similar(wavefront.data)
+    ifft_output = similar(wavefront.data)
+    fft_plan = CUFFT.plan_fft(wavefront.data)
+    ifft_plan = CUFFT.plan_ifft(wavefront.data)
 
-    fftholo = CUFFT.fftshift(CUFFT.fft(wavefront.data))
+    LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
+    fftholo = CUFFT.fftshift(fftholo_fft)
     fftholo .= fftholo .* transfer_front.data
 
-    proj .= fftholo |> CUFFT.ifftshift |> CUFFT.ifft |> (x -> x .* conj.(x)) .|> abs .|> Float32
+    _ifft_abs2_float32!(proj, fftholo, ifft_plan, ifft_workspace, ifft_output)
 
     for i in 2:slices
         fftholo .= fftholo .* transfer_dz.data
-        projtmp .= fftholo |> CUFFT.ifftshift |> CUFFT.ifft |> (x -> x .* conj.(x)) .|> abs .|> Float32
+        _ifft_abs2_float32!(projtmp, fftholo, ifft_plan, ifft_workspace, ifft_output)
         proj .= CUDA.min.(proj, projtmp)
     end
 
@@ -301,15 +343,21 @@ function cu_get_reconst_vol_and_xyprojection(wavefront::CuWavefront{ComplexF32},
     @assert size(wavefront.data) == size(transfer_front.data) == size(transfer_dz.data) "All arrays must have the same size. Got $(size(wavefront.data)), $(size(transfer_front.data)), $(size(transfer_dz.data))."
 
     vol = CuArray{return_type}(undef, size(wavefront.data)..., slices)
+    fftholo_fft = similar(wavefront.data)
+    ifft_workspace = similar(wavefront.data)
+    ifft_output = similar(wavefront.data)
+    fft_plan = CUFFT.plan_fft(wavefront.data)
+    ifft_plan = CUFFT.plan_ifft(wavefront.data)
 
-    fftholo = CUFFT.fftshift(CUFFT.fft(wavefront.data))
+    LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
+    fftholo = CUFFT.fftshift(fftholo_fft)
     fftholo .= fftholo .* transfer_front.data
 
-    vol[:, :, 1] .= _ifft_and_abs(fftholo, return_type)
+    _ifft_and_abs!(view(vol, :, :, 1), fftholo, return_type, ifft_plan, ifft_workspace, ifft_output)
 
     for i in 2:slices
         fftholo .= fftholo .* transfer_dz.data
-        vol[:, :, i] .= _ifft_and_abs(fftholo, return_type)
+        _ifft_and_abs!(view(vol, :, :, i), fftholo, return_type, ifft_plan, ifft_workspace, ifft_output)
     end
 
     xyprojection = CuArray{Float32}(undef, size(wavefront.data)...)
@@ -342,16 +390,24 @@ function cu_get_reconst_vol_and_xyprojection_padded(wavefront::CuWavefront{Compl
 
     datlen = size(wavefront.data, 1)
     vol = CuArray{return_type}(undef, datlen, datlen, slices)
+    padded_wavefront = cu_2d_pad(wavefront.data)
+    fftholo_fft = similar(padded_wavefront)
+    ifft_workspace = similar(padded_wavefront)
+    ifft_output = similar(padded_wavefront)
+    fft_plan = CUFFT.plan_fft(padded_wavefront)
+    ifft_plan = CUFFT.plan_ifft(padded_wavefront)
 
-    fftholo = CUFFT.fftshift(CUFFT.fft(cu_2d_pad(wavefront.data)))
+    LinearAlgebra.mul!(fftholo_fft, fft_plan, padded_wavefront)
+    fftholo = CUFFT.fftshift(fftholo_fft)
     fftholo .= fftholo .* transfer_front.data
 
-    tmparr = _ifft_and_abs(fftholo, return_type)
+    tmparr = CuArray{return_type}(undef, size(padded_wavefront)...)
+    _ifft_and_abs!(tmparr, fftholo, return_type, ifft_plan, ifft_workspace, ifft_output)
     vol[:, :, 1] .= tmparr[div(datlen,2)+1:3*div(datlen,2), div(datlen,2)+1:3*div(datlen,2)]
 
     for i in 2:slices
         fftholo .= fftholo .* transfer_dz.data
-        tmparr .= _ifft_and_abs(fftholo, return_type)
+        _ifft_and_abs!(tmparr, fftholo, return_type, ifft_plan, ifft_workspace, ifft_output)
         vol[:, :, i] .= tmparr[div(datlen,2)+1:3*div(datlen,2), div(datlen,2)+1:3*div(datlen,2)]
     end
 
@@ -383,6 +439,13 @@ Perform angular spectrum method-based propagation of the wavefront `inholo` by d
 function cu_asm_prop!(outholo::CuWavefront, inholo::CuWavefront, d_sqr::CuTransferSqrtPart,
                     zprop::Float64, datlen::Int, λ::Float64)
     tf = cu_transfer(zprop, datlen, λ, d_sqr)
-    outholo.data .= CUFFT.ifft(CUFFT.ifftshift(CUFFT.fftshift(CUFFT.fft(inholo.data)) .* tf.data))
+    fft_arr = similar(inholo.data)
+    ifft_in = similar(inholo.data)
+    fft_plan = CUFFT.plan_fft(inholo.data)
+    ifft_plan = CUFFT.plan_ifft(inholo.data)
+
+    LinearAlgebra.mul!(fft_arr, fft_plan, inholo.data)
+    ifft_in .= CUFFT.ifftshift(CUFFT.fftshift(fft_arr) .* tf.data)
+    LinearAlgebra.mul!(outholo.data, ifft_plan, ifft_in)
     return nothing
 end


### PR DESCRIPTION
## Summary
- switch repeated CUDA FFT/IFFT hot paths to reusable CUFFT plans in src/holofunc.jl
- apply the same planned FFT/IFFT flow in src/frequency_filters.jl
- bump package version to 0.2.2
- set docs/Project.toml compat to ParticleHolography = 0.2.2

## Why
Several reconstruction and filtering loops repeatedly invoked FFT/IFFT directly. Reusing plans per call-site for fixed array shape/type avoids repeated planning overhead while preserving algorithm flow (fftshift/ifftshift, transfer multiplication, and output conversions).

## Validation
- julia --project -e "using Pkg; Pkg.resolve(); Pkg.instantiate(); Pkg.test()"
- julia --project -e "using Pkg; Pkg.test()"
- both runs passed with 108/108 tests
