### PR TITLE
Update CUDA stack for v0.2.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,15 +30,15 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -52,10 +52,10 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: self-hosted
     timeout-minutes: 60
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      actions: write
+    permissions:
       contents: read
     strategy:
       fail-fast: false
@@ -34,7 +33,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v3
+      # The self-hosted runner keeps its Julia depot locally; avoid uploading multi-GB CUDA artifacts.
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /docs/Manifest.toml
 /docs/build/
 /dev/
+tmp/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParticleHolography"
 uuid = "b8f7f481-73e0-42c6-b6bd-c66d3b4942cc"
 authors = ["Dai Nakai <dnakaikit@gmail.com> and contributors"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -25,25 +25,27 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+cuFFT = "533571aa-0936-420e-b4be-9c66f5f626ca"
 
 [compat]
-CUDA = "5"
-CairoMakie = "0.12, 0.13"
+CUDA = "6"
+CairoMakie = "0.12, 0.13, 0.14, 0.15"
 Colors = "0.12, 0.13"
 FileIO = "1"
-FixedPointNumbers = "0.8"
+FixedPointNumbers = "0.8, 0.9"
 Glob = "1"
 Graphs = "1"
 HistogramThresholding = "0.3"
 ImageFiltering = "0.7"
 Images = "0.26"
-JSON = "0.21"
-Makie = "0.21, 0.22"
-MetaGraphsNext = "0.7"
+JSON = "0.21, 1"
+Makie = "0.21, 0.22, 0.23, 0.24"
+MetaGraphsNext = "0.7, 0.8"
 Plots = "1"
 ProgressMeter = "1"
 Statistics = "1"
 StatsBase = "0.34"
+cuFFT = "6"
 julia = "1.8"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,4 +6,4 @@ LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 ParticleHolography = "b8f7f481-73e0-42c6-b6bd-c66d3b4942cc"
 
 [compat]
-ParticleHolography = "0.2.2"
+ParticleHolography = "0.2.4"

--- a/src/bundleadjustment.jl
+++ b/src/bundleadjustment.jl
@@ -391,7 +391,7 @@ function get_distortion_coefficients(img1::Array{<:AbstractFloat,2}, img2::Array
 
         norm_strObservable = lift(x -> normalize_values(x), strObservable)
         arrow_colors = lift(x -> color_mapping(x), norm_strObservable)
-        arrows!(arrowax, xs, ys, vecxObservable, vecyObservable, arrowsize=10, lengthscale=20, arrowcolor=arrow_colors, linecolor=arrow_colors)
+        arrows2d!(arrowax, xs, ys, vecxObservable, vecyObservable, tiplength=10, tipwidth=10, lengthscale=20, tipcolor=arrow_colors, shaftcolor=arrow_colors)
         firstcolor = Colorbar(f[1, 4], limits=(0, maximum(vec(sqrt.(vecArray[:, :, 1] .^ 2 .+ vecArray[:, :, 2] .^ 2)))), colormap=:viridis)
         Makie.save("./"*save_dir*"/before_BA." * save_extension, f)
         img3 = quadratic_distortion_correction(img2, coefa)

--- a/src/frequency_filters.jl
+++ b/src/frequency_filters.jl
@@ -1,5 +1,5 @@
 using CUDA
-using CUDA.CUFFT
+using cuFFT
 using LinearAlgebra
 
 export cu_rectangle_filter, cu_super_gaussian_filter, cu_apply_low_pass_filter, cu_apply_low_pass_filter!
@@ -90,11 +90,11 @@ Apply a low pass filter to the wavefront `holo`. The low pass filter is applied 
 function cu_apply_low_pass_filter!(holo::CuWavefront, lpf::CuLowPassFilter)
     fft_arr = similar(holo.data)
     ifft_in = similar(holo.data)
-    fft_plan = CUFFT.plan_fft(holo.data)
-    ifft_plan = CUFFT.plan_ifft(holo.data)
+    fft_plan = cuFFT.plan_fft(holo.data)
+    ifft_plan = cuFFT.plan_ifft(holo.data)
 
     LinearAlgebra.mul!(fft_arr, fft_plan, holo.data)
-    ifft_in .= CUFFT.ifftshift(lpf.data .* CUFFT.fftshift(fft_arr))
+    ifft_in .= cuFFT.ifftshift(lpf.data .* cuFFT.fftshift(fft_arr))
     LinearAlgebra.mul!(holo.data, ifft_plan, ifft_in)
     return nothing
 end
@@ -115,11 +115,11 @@ function cu_apply_low_pass_filter(holo::CuWavefront, lpf::CuLowPassFilter)
     fft_arr = similar(holo.data)
     ifft_in = similar(holo.data)
     filtered = similar(holo.data)
-    fft_plan = CUFFT.plan_fft(holo.data)
-    ifft_plan = CUFFT.plan_ifft(holo.data)
+    fft_plan = cuFFT.plan_fft(holo.data)
+    ifft_plan = cuFFT.plan_ifft(holo.data)
 
     LinearAlgebra.mul!(fft_arr, fft_plan, holo.data)
-    ifft_in .= CUFFT.ifftshift(lpf.data .* CUFFT.fftshift(fft_arr))
+    ifft_in .= cuFFT.ifftshift(lpf.data .* cuFFT.fftshift(fft_arr))
     LinearAlgebra.mul!(filtered, ifft_plan, ifft_in)
     return CuWavefront(filtered)
 end

--- a/src/holofunc.jl
+++ b/src/holofunc.jl
@@ -1,5 +1,5 @@
 using CUDA
-using CUDA.CUFFT
+using cuFFT
 using FixedPointNumbers
 using LinearAlgebra
 
@@ -111,8 +111,8 @@ function cu_phase_retrieval_holo(holo1::CuArray{Float32,2}, holo2::CuArray{Float
     sqrtI2 = sqrt.(holo2)
     transfer_fft_order = _transfer_fft_order(transfer)
     invtransfer_fft_order = _transfer_fft_order(invtransfer)
-    fft_plan = CUFFT.plan_fft(light1)
-    ifft_plan = CUFFT.plan_ifft(light1)
+    fft_plan = cuFFT.plan_fft(light1)
+    ifft_plan = cuFFT.plan_ifft(light1)
 
     light1 .= sqrtI1 .+ 0.0im
 
@@ -167,7 +167,7 @@ function _normedfloat_to_N0f8(val::AbstractFloat)
 end
 
 function _transfer_fft_order(transfer::CuTransfer{T}) where {T<:Complex}
-    return CUFFT.ifftshift(transfer.data)
+    return cuFFT.ifftshift(transfer.data)
 end
 
 function _ifft_from_fft_order!(out::AbstractArray{T,2}, fftholo::CuArray{T,2}, ifft_plan) where {T<:Complex}
@@ -217,8 +217,8 @@ function cu_get_reconst_vol(wavefront::CuWavefront{ComplexF32}, transfer_front::
     ifft_output = similar(wavefront.data)
     transfer_front_fft_order = _transfer_fft_order(transfer_front)
     transfer_dz_fft_order = _transfer_fft_order(transfer_dz)
-    fft_plan = CUFFT.plan_fft(wavefront.data)
-    ifft_plan = CUFFT.plan_ifft(wavefront.data)
+    fft_plan = cuFFT.plan_fft(wavefront.data)
+    ifft_plan = cuFFT.plan_ifft(wavefront.data)
 
     LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
     fftholo_fft .= fftholo_fft .* transfer_front_fft_order
@@ -254,8 +254,8 @@ function cu_get_reconst_complex_vol(wavefront::CuWavefront{ComplexF32}, transfer
     fftholo_fft = similar(wavefront.data)
     transfer_front_fft_order = _transfer_fft_order(transfer_front)
     transfer_dz_fft_order = _transfer_fft_order(transfer_dz)
-    fft_plan = CUFFT.plan_fft(wavefront.data)
-    ifft_plan = CUFFT.plan_ifft(wavefront.data)
+    fft_plan = cuFFT.plan_fft(wavefront.data)
+    ifft_plan = cuFFT.plan_ifft(wavefront.data)
 
     LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
     fftholo_fft .= fftholo_fft .* transfer_front_fft_order
@@ -293,8 +293,8 @@ function cu_get_reconst_xyprojection(wavefront::CuWavefront{ComplexF32}, transfe
     ifft_output = similar(wavefront.data)
     transfer_front_fft_order = _transfer_fft_order(transfer_front)
     transfer_dz_fft_order = _transfer_fft_order(transfer_dz)
-    fft_plan = CUFFT.plan_fft(wavefront.data)
-    ifft_plan = CUFFT.plan_ifft(wavefront.data)
+    fft_plan = cuFFT.plan_fft(wavefront.data)
+    ifft_plan = cuFFT.plan_ifft(wavefront.data)
 
     LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
     fftholo_fft .= fftholo_fft .* transfer_front_fft_order
@@ -350,8 +350,8 @@ function cu_get_reconst_vol_and_xyprojection(wavefront::CuWavefront{ComplexF32},
     ifft_output = similar(wavefront.data)
     transfer_front_fft_order = _transfer_fft_order(transfer_front)
     transfer_dz_fft_order = _transfer_fft_order(transfer_dz)
-    fft_plan = CUFFT.plan_fft(wavefront.data)
-    ifft_plan = CUFFT.plan_ifft(wavefront.data)
+    fft_plan = cuFFT.plan_fft(wavefront.data)
+    ifft_plan = cuFFT.plan_ifft(wavefront.data)
 
     LinearAlgebra.mul!(fftholo_fft, fft_plan, wavefront.data)
     fftholo_fft .= fftholo_fft .* transfer_front_fft_order
@@ -398,8 +398,8 @@ function cu_get_reconst_vol_and_xyprojection_padded(wavefront::CuWavefront{Compl
     ifft_output = similar(padded_wavefront)
     transfer_front_fft_order = _transfer_fft_order(transfer_front)
     transfer_dz_fft_order = _transfer_fft_order(transfer_dz)
-    fft_plan = CUFFT.plan_fft(padded_wavefront)
-    ifft_plan = CUFFT.plan_ifft(padded_wavefront)
+    fft_plan = cuFFT.plan_fft(padded_wavefront)
+    ifft_plan = cuFFT.plan_ifft(padded_wavefront)
 
     LinearAlgebra.mul!(fftholo_fft, fft_plan, padded_wavefront)
     fftholo_fft .= fftholo_fft .* transfer_front_fft_order
@@ -444,8 +444,8 @@ function cu_asm_prop!(outholo::CuWavefront, inholo::CuWavefront, d_sqr::CuTransf
     tf = cu_transfer(zprop, datlen, λ, d_sqr)
     tf_fft_order = _transfer_fft_order(tf)
     fft_arr = similar(inholo.data)
-    fft_plan = CUFFT.plan_fft(inholo.data)
-    ifft_plan = CUFFT.plan_ifft(inholo.data)
+    fft_plan = cuFFT.plan_fft(inholo.data)
+    ifft_plan = cuFFT.plan_ifft(inholo.data)
 
     LinearAlgebra.mul!(fft_arr, fft_plan, inholo.data)
     fft_arr .= fft_arr .* tf_fft_order


### PR DESCRIPTION
## Summary

- bump the package/docs version to v0.2.4
- require CUDA.jl 6 and add cuFFT as a direct dependency
- migrate deprecated `CUDA.CUFFT` usage to the `cuFFT` package
- update Makie arrow plotting for Makie 0.24
- incorporate the GitHub Actions updates from #55, #56, and #57

## Validation

- `Pkg.resolve()`
- `Pkg.resolve()` in the docs environment
- `Pkg.test()` (108/108 passed)
- `julia --project=docs docs/make.jl`
- minimal cuFFT plan/shift round-trip checks
- YAML parse check for `.github/workflows/CI.yml`

Supersedes #55, #56, and #57.